### PR TITLE
Modenised C code: Use PyVarObject_HEAD_INIT.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changelog
 2.13.3 (unreleased)
 -------------------
 
+- Modernised C code in preparation of porting to Python 3.
 
 2.13.2 (2011-12-12)
 -------------------

--- a/include/ExtensionClass/ExtensionClass.h
+++ b/include/ExtensionClass/ExtensionClass.h
@@ -214,7 +214,7 @@ static PyExtensionClass NAME ## Type = { PyObject_HEAD_INIT(NULL) 0, # NAME, \
 /* Check whether an object has an __of__ method for returning itself
    in the context of it's container. */
 #define has__of__(O) (PyObject_TypeCheck((O)->ob_type, ECExtensionClassType) \
-                      && (O)->ob_type->tp_descr_get != NULL)
+                      && Py_TYPE(O)->tp_descr_get != NULL)
 
 /* The following macros are used to check whether an instance
    or a class' instanses have instance dictionaries: */
@@ -256,9 +256,9 @@ static PyExtensionClass NAME ## Type = { PyObject_HEAD_INIT(NULL) 0, # NAME, \
 #undef PyObject_DEL
 
 #define PyMem_DEL(O)                                   \
-  if (((O)->ob_type->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
-      && ((O)->ob_type->tp_free != NULL))              \
-    (O)->ob_type->tp_free((PyObject*)(O));             \
+  if ((Py_TYPE(O)->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
+      && (Py_TYPE(O)->tp_free != NULL))              \
+    Py_TYPE(O)->tp_free((PyObject*)(O));             \
   else                                                 \
     PyObject_FREE((O));
 

--- a/src/DocumentTemplate/cDocumentTemplate.c
+++ b/src/DocumentTemplate/cDocumentTemplate.c
@@ -179,8 +179,7 @@ static char InstanceDicttype__doc__[] =
 ;
 
 static PyExtensionClass InstanceDictType = {
-  PyObject_HEAD_INIT(NULL)
-  0,				/*ob_size*/
+  PyVarObject_HEAD_INIT(NULL, 0) 	/*ob_size*/
   "InstanceDict",			/*tp_name*/
   sizeof(InstanceDictobject),	/*tp_basicsize*/
   0,				/*tp_itemsize*/
@@ -528,8 +527,7 @@ DictInstance_getattr(DictInstance *self, PyObject *name)
 }
 
 static PyTypeObject DictInstanceType = {
-  PyObject_HEAD_INIT(NULL)
-  0,				/*ob_size*/
+  PyVarObject_HEAD_INIT(NULL, 0) 	/*ob_size*/
   "DictInstance",			/*tp_name*/
   sizeof(DictInstance),		/*tp_basicsize*/
   0,				/*tp_itemsize*/
@@ -609,8 +607,7 @@ static char MMtype__doc__[] =
 ;
 
 static PyExtensionClass MMtype = {
-	PyObject_HEAD_INIT(NULL)
-	0,				/*ob_size*/
+        PyVarObject_HEAD_INIT(NULL, 0)  /*ob_size*/
 	"TemplateDict",			/*tp_name*/
 	sizeof(MM),			/*tp_basicsize*/
 	0,				/*tp_itemsize*/

--- a/src/DocumentTemplate/cDocumentTemplate.c
+++ b/src/DocumentTemplate/cDocumentTemplate.c
@@ -83,7 +83,7 @@ InstanceDict_dealloc(InstanceDictobject *self)
   Py_XDECREF(self->cache);
   Py_XDECREF(self->namespace);
   Py_XDECREF(self->guarded_getattr);
-  Py_DECREF(self->ob_type);
+  Py_DECREF(Py_TYPE(self));
   PyObject_DEL(self);
 }
 
@@ -436,7 +436,7 @@ MM_dealloc(MM *self)
 {
   Py_XDECREF(self->data);
   Py_XDECREF(self->dict);
-  Py_DECREF(self->ob_type);
+  Py_DECREF(Py_TYPE(self));
   PyObject_DEL(self);
 }
 
@@ -567,7 +567,7 @@ MM_call(MM *self, PyObject *args, PyObject *kw)
   if (args && (l=PyTuple_Size(args)) < 0) return NULL;
   if (l)
     {
-      UNLESS(r=PyObject_CallObject(OBJECT(self->ob_type), NULL)) return NULL;
+      UNLESS(r=PyObject_CallObject(OBJECT(Py_TYPE(self)), NULL)) return NULL;
       for (i=0; i < l; i++) 
 	if (PyList_Append(((MM*)r)->data, PyTuple_GET_ITEM(args, i)) < 0) 
 	  goto err;
@@ -967,7 +967,7 @@ initcDocumentTemplate(void)
 {
   PyObject *m, *d;
 
-  DictInstanceType.ob_type=&PyType_Type;
+  Py_TYPE(&DictInstanceType)=&PyType_Type;
 
   UNLESS (html_quote = PyImport_ImportModule("DocumentTemplate.html_quote")) return;
   ASSIGN(ustr, PyObject_GetAttrString(html_quote, "ustr"));


### PR DESCRIPTION
These are changes compatible with all supported Python 2 versions, but made in preparation of porting to Python 3. Making these changes outside a Python 3 porting branch allows us to keep the interesting part of the porting smaller and also testing as many changes as possible based on the green bar we have on Python 2.