### PR TITLE
Do not restrict version of ExtensionClass. [2.13 branch]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='DocumentTemplate',
       install_requires=[
         'AccessControl',
         'Acquisition',
-        'ExtensionClass<4.0.dev',
+        'ExtensionClass',
         'RestrictedPython',
         'zExceptions',
         'zope.sequencesort',


### PR DESCRIPTION
Plone 5 is using ExtensionClass 4.1.2, in combination with Acquisition 4.2.2.
That is running fine.
And `bin/test` in DocumentTemplate runs fine when I use those version pins.

It is good to keep running the DocumentTemplate tests with the older versions, but restricting the version in `setup.py` seems unneeded to me.

Cc @tseaver @hannosch 