### PR TITLE
Convert doctest into unittest.

### DIFF
--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -13,53 +13,54 @@
 """Tests for functions and classes in DT_Var.
 """
 
-import doctest
 import unittest
 
 
-class TestNewlineToBr(doctest.DocTestCase):
+class TestNewlineToBr(unittest.TestCase):
 
     def test_newline_to_br(self):
-        r"""
+        """
         newline_to_br should work identically with either DOS-style or
         Unix-style newlines.
-
-        >>> from DocumentTemplate import DT_Var
-        >>> text = '''
-        ... line one
-        ... line two
-        ...
-        ... line three
-        ... '''
-        >>> print(DT_Var.newline_to_br(text))
-        <br />
-        line one<br />
-        line two<br />
-        <br />
-        line three<br />
-        <BLANKLINE>
-
-        >>> dos = text.replace('\n', '\r\n')
-        >>> DT_Var.newline_to_br(text) == DT_Var.newline_to_br(dos)
-        True
         """
+        from DocumentTemplate import DT_Var
+        text = '''\
+
+line one
+line two
+
+line three
+'''
+        self.assertEqual(
+            DT_Var.newline_to_br(text),
+            '''\
+<br />
+line one<br />
+line two<br />
+<br />
+line three<br />
+''')
+
+        dos = text.replace('\n', '\r\n')
+        self.assertEqual(DT_Var.newline_to_br(text), DT_Var.newline_to_br(dos))
 
     def test_newline_to_br_tainted(self):
-        """
-        >>> from DocumentTemplate import DT_Var
-        >>> text = '''
-        ... <li>line one</li>
-        ... <li>line two</li>
-        ... '''
-        >>> from AccessControl.tainted import TaintedString
-        >>> tainted = TaintedString(text)
-        >>> print(DT_Var.newline_to_br(tainted))
-        <br />
-        &lt;li&gt;line one&lt;/li&gt;<br />
-        &lt;li&gt;line two&lt;/li&gt;<br />
-        <BLANKLINE>
+        from DocumentTemplate import DT_Var
+        text = '''\
 
-        """
+<li>line one</li>
+<li>line two</li>
+'''
+
+        from AccessControl.tainted import TaintedString
+        tainted = TaintedString(text)
+        self.assertEqual(
+            DT_Var.newline_to_br(tainted),
+            '''\
+<br />
+&lt;li&gt;line one&lt;/li&gt;<br />
+&lt;li&gt;line two&lt;/li&gt;<br />
+''')
 
 
 class TestUrlQuoting(unittest.TestCase):
@@ -93,10 +94,3 @@ class TestUrlQuoting(unittest.TestCase):
             url_unquote_plus(quoted_unicode_value), unicode_value)
         self.assertEquals(
             url_unquote_plus(quoted_utf8_value), utf8_value)
-
-
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(doctest.DocTestSuite())
-    suite.addTest(unittest.makeSuite(TestUrlQuoting))
-    return suite


### PR DESCRIPTION
I've removed the test_suite function, as all the modern testrunners can auto-detect test classes based on unittest.