### PR TITLE
Avoid mutating kwargs dict while iterating.

### DIFF
--- a/src/DocumentTemplate/DT_In.py
+++ b/src/DocumentTemplate/DT_In.py
@@ -514,7 +514,7 @@ class InClass(object):
                                   self.start_name_re, prefix)
         kw = vars.data
         pkw = add_with_prefix(kw, 'sequence', prefix)
-        for k, v in kw.items():
+        for k, v in list(kw.items()):
             pkw[k] = v
         pkw['sequence-step-size'] = sz
         pkw['sequence-step-overlap'] = overlap
@@ -697,7 +697,7 @@ class InClass(object):
         vars = sequence_variables(sequence, alt_prefix=prefix)
         kw = vars.data
         pkw = add_with_prefix(kw, 'sequence', prefix)
-        for k, v in kw.items():
+        for k, v in list(kw.items()):
             pkw[k] = v
         kw['mapping'] = mapping
 


### PR DESCRIPTION
The `add_with_prefix` helper may return the original dict, if no prefix is set, which causes an error under Python3.

Closes #10.

I'm ashamed to say that I balked at the idea of creating `test_DT_In.py` from scratch just to provoke #10 before fixing it.  I did verify that both sites are exercised by the quasi-functests.