### PR TITLE
Bytes problems fixed: decode_seq() now clean. URL generation fixed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.0b3 (unreleased)
 ------------------
 
+- Fixed a problem with Python 3 compatibility when computing the
+  state strings in tree tags.
+
 
 3.0b2 (2017-11-03)
 ------------------

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -396,11 +396,11 @@ def tpRenderTABLE(self, id, root_url, url, state, substate, diff, data,
                 ptreeData['tree-item-expanded'] = 1
                 output('<a name="%s" href="%s?%stree-c=%s#%s">'
                        '<img src="%s/p_/mi" alt="-" border="0" /></a>' %
-                       (id, root_url, param, s, id, script))
+                       (id, root_url, param, s.decode('ascii'), id, script))
             else:
                 output('<a name="%s" href="%s?%stree-e=%s#%s">'
                        '<img src="%s/p_/pl" alt="+" border="0" /></a>' %
-                       (id, root_url, param, s, id, script))
+                       (id, root_url, param, s.decode('ascii'), id, script))
             output('</td>\n')
 
         else:
@@ -643,6 +643,9 @@ def encode_str(state):
 
 def decode_seq(state):
     "Convert an encoded string to a sequence"
+    if not isinstance(state, bytes):
+        state = state.encode('ascii')
+
     state = state.translate(tminus)
     l = len(state)
 
@@ -659,14 +662,14 @@ def decode_seq(state):
             l = len(state)
             k = l % 4
             if k:
-                state = state + '=' * (4 - k)
+                state = state + b'=' * (4 - k)
             states.append(a2b_base64(state))
-        state = ''.join(states)
+        state = b''.join(states)
     else:
         l = len(state)
         k = l % 4
         if k:
-            state = state + '=' * (4 - k)
+            state = state + b'=' * (4 - k)
         state = a2b_base64(state)
 
     state = decompress(state)

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -396,11 +396,11 @@ def tpRenderTABLE(self, id, root_url, url, state, substate, diff, data,
                 ptreeData['tree-item-expanded'] = 1
                 output('<a name="%s" href="%s?%stree-c=%s#%s">'
                        '<img src="%s/p_/mi" alt="-" border="0" /></a>' %
-                       (id, root_url, param, s.decode('ascii'), id, script))
+                       (id, root_url, param, s, id, script))
             else:
                 output('<a name="%s" href="%s?%stree-e=%s#%s">'
                        '<img src="%s/p_/pl" alt="+" border="0" /></a>' %
-                       (id, root_url, param, s.decode('ascii'), id, script))
+                       (id, root_url, param, s, id, script))
             output('</td>\n')
 
         else:


### PR DESCRIPTION
Clicking on the "plus" signs in the left panel of the ZMI yielded annoying site errors about bytes vs. str.
Two causes: 1. the URL was generated with %s and a bytes param. %s renders the bytes as repr(), adding b'' around the parameter. 2. decode_seq() died if the input was str.
Both issues are fixed in this patch.