### PR TITLE
Run the tests with the current state of the code.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,3 +14,6 @@ eggs = tox
 [test]
 recipe = zc.recipe.testrunner
 eggs = DocumentTemplate
+
+[versions]
+DocumentTemplate =


### PR DESCRIPTION
It seems we used the released version, which was picked in the `versions-prod.cfg` for some time now.