### PR TITLE
Improve flake8 compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,13 @@ install:
     - pip install coveralls coverage
     - pip install zc.buildout
     - pip install -U six==1.10.0
+    - pip install flake8
     - buildout bootstrap
     - buildout
 
 script:
     - coverage run bin/test -v1
+    - flake8 --doctests src tests setup.py
 after_success:
     - coverage combine
     - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Improve compatibility with flake8.
+- Update deprecated assert method calls.
 
 
 3.0b3 (2018-04-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve compatibility with flake8.
 
 
 3.0b3 (2018-04-18)

--- a/src/DocumentTemplate/DT_HTML.py
+++ b/src/DocumentTemplate/DT_HTML.py
@@ -45,9 +45,9 @@ class dtml_re_class:
 
                 mo = end_match(text, n)
                 if mo is not None:
-                    l = mo.end(0) - mo.start(0)
-                    end = text[n:n + l].strip()
-                    n = n + l
+                    l_ = mo.end(0) - mo.start(0)
+                    end = text[n:n + l_].strip()
+                    n = n + l_
                 else:
                     end = ''
 
@@ -83,10 +83,10 @@ class dtml_re_class:
                     e = text.find(';', n)
                     if e >= 0:
                         args = text[n:e]
-                        l = len(args)
+                        l_ = len(args)
                         mo = ent_name(args)
                         if mo is not None:
-                            if mo.end(0) - mo.start(0) == l:
+                            if mo.end(0) - mo.start(0) == l_:
                                 d = self.__dict__
                                 if text[s + 5] == '-':
                                     d[1] = d['end'] = ''
@@ -97,7 +97,7 @@ class dtml_re_class:
                                     return self
                                 else:
                                     nn = args.find('-')
-                                    if nn >= 0 and nn < l - 1:
+                                    if nn >= 0 and nn < l_ - 1:
                                         d[1] = d['end'] = ''
                                         d[2] = d['name'] = 'var'
                                         d[0] = text[s:e + 1]
@@ -115,9 +115,9 @@ class dtml_re_class:
         mo = name_match(text, n)
         if mo is None:
             return None
-        l = mo.end(0) - mo.start(0)
+        l_ = mo.end(0) - mo.start(0)
 
-        a = n + l
+        a = n + l_
         name = text[n:a].strip()
 
         args = text[a:e].strip()
@@ -184,9 +184,10 @@ class HTML(String):
             if name == 'else' and args:
                 # Waaaaaah! Have to special case else because of
                 # old else start tag usage. Waaaaaaah!
-                l = len(args)
+                l_ = len(args)
                 if not (args == sargs or
-                        args == sargs[:l] and sargs[l:l + 1] in ' \t\n'):
+                        args == sargs[:l_] and
+                        sargs[l_:l_ + 1] in ' \t\n'):
                     return tag, args, self.commands[name], None
 
             return tag, args, None, name

--- a/src/DocumentTemplate/DT_In.py
+++ b/src/DocumentTemplate/DT_In.py
@@ -702,8 +702,8 @@ class InClass(object):
             pkw[k] = v
         kw['mapping'] = mapping
 
-        l = len(sequence)
-        last = l - 1
+        l_ = len(sequence)
+        last = l_ - 1
 
         push = md._push
         pop = md._pop
@@ -716,7 +716,7 @@ class InClass(object):
             result = []
             append = result.append
             guarded_getitem = getattr(md, 'guarded_getitem', None)
-            for index in range(l):
+            for index in range(l_):
                 if index == last:
                     pkw['sequence-end'] = 1
                 if guarded_getitem is not None:
@@ -901,14 +901,14 @@ def make_sortfunctions(sortfields, md):
     sf_list = []
     for field in sortfields:
         f = field.split('/')
-        l = len(f)
+        l_ = len(f)
 
-        if l == 1:
+        if l_ == 1:
             f.append("cmp")
             f.append("asc")
-        elif l == 2:
+        elif l_ == 2:
             f.append("asc")
-        elif l == 3:
+        elif l_ == 3:
             pass
         else:
             raise SyntaxError(
@@ -954,15 +954,15 @@ class SortBy(object):
             o2 = o2[0]
 
         sf_list = self.sf_list
-        l = len(sf_list)
+        l_ = len(sf_list)
 
         # assert that o1 and o2 are tuples of apropriate length
-        assert len(o1) == l + 1 - multsort, "%s, %d" % (o1, l + multsort)
-        assert len(o2) == l + 1 - multsort, "%s, %d" % (o2, l + multsort)
+        assert len(o1) == l_ + 1 - multsort, "%s, %d" % (o1, l_ + multsort)
+        assert len(o2) == l_ + 1 - multsort, "%s, %d" % (o2, l_ + multsort)
 
         # now run through the list of functions in sf_list and
         # compare every object in o1 and o2
-        for i in range(l):
+        for i in range(l_):
             # if multsort - we already extracted the key list
             # if not multsort - i is 0, and the 0th element is the key
             c1, c2 = o1[i], o2[i]

--- a/src/DocumentTemplate/DT_InSV.py
+++ b/src/DocumentTemplate/DT_InSV.py
@@ -19,7 +19,7 @@ import re
 try:
     import Missing
     mv = Missing.Value
-except:
+except ImportError:
     mv = None
 
 TupleType = tuple
@@ -226,7 +226,7 @@ class sequence_variables(object):
                             min = item
                         if item > max:
                             max = item
-                except:
+                except TypeError:
                     if item is not None and item is not mv:
                         if smin is None:
                             smin = smax = item
@@ -259,7 +259,7 @@ class sequence_variables(object):
             else:
                 data['variance-%s' % name] = ''
                 data['standard-deviation-%s' % name] = ''
-        except:
+        except ZeroDivisionError:
             if min is None:
                 min, max, values = smin, smax, svalues
             else:

--- a/src/DocumentTemplate/DT_InSV.py
+++ b/src/DocumentTemplate/DT_InSV.py
@@ -147,8 +147,8 @@ class sequence_variables(object):
         return self.value(index, name) != self.value(index + 1, name)
 
     def length(self, ignored):
-        l = self['sequence-length'] = len(self.items)
-        return l
+        l_ = self['sequence-length'] = len(self.items)
+        return l_
 
     def query(self, *ignored):
 
@@ -166,17 +166,17 @@ class sequence_variables(object):
                 mo = reg.search(query_string)
                 if mo is not None:
                     v = mo.group(0)
-                    l = mo.start(0)
-                    query_string = (query_string[:l] +
-                                    query_string[l + len(v) - 1:])
+                    l_ = mo.start(0)
+                    query_string = (query_string[:l_] +
+                                    query_string[l_ + len(v) - 1:])
 
             else:
-                l = reg.search_group(query_string, (0,))
-                if l:
-                    v = l[1]
-                    l = l[0]
-                    query_string = (query_string[:l] +
-                                    query_string[l + len(v) - 1:])
+                l_ = reg.search_group(query_string, (0,))
+                if l_:
+                    v = l_[1]
+                    l_ = l_[0]
+                    query_string = (query_string[:l_] +
+                                    query_string[l_ + len(v) - 1:])
 
             query_string = '?' + query_string[1:]
         else:
@@ -306,13 +306,13 @@ class sequence_variables(object):
             sz = data['sequence-step-size']
             start = data['sequence-step-start']
             end = data['sequence-step-end']
-            l = len(sequence)
+            l_ = len(sequence)
             orphan = data['sequence-step-orphan']
             overlap = data['sequence-step-overlap']
         except Exception:
             pass
         r = []
-        while end < l:
+        while end < l_:
             start, end, spam = opt(end + 1 - overlap, 0,
                                    sz, orphan, sequence)
             v = sequence_variables(self.items,
@@ -386,8 +386,8 @@ class sequence_variables(object):
         if key in data:
             return data[key]
 
-        l = key.rfind('-')
-        if l < 0:
+        l_ = key.rfind('-')
+        if l_ < 0:
             alt_prefix = self.alt_prefix
             if not (alt_prefix and key.startswith(alt_prefix)):
                 raise KeyError(key)
@@ -401,8 +401,8 @@ class sequence_variables(object):
             prefix = 'sequence'
             key = 'sequence-' + suffix
         else:
-            suffix = key[l + 1:]
-            prefix = key[:l]
+            suffix = key[l_ + 1:]
+            prefix = key[:l_]
 
         if hasattr(self, suffix):
             try:

--- a/src/DocumentTemplate/DT_Let.py
+++ b/src/DocumentTemplate/DT_Let.py
@@ -104,11 +104,11 @@ def parse_let_params(
     if mo is not None:
         name = mo.group(2)
         value = mo.group(3)
-        l = len(mo.group(1))
+        l_ = len(mo.group(1))
     elif mo1 is not None:
         name = mo1.group(2)
         value = '"%s"' % mo1.group(3)
-        l = len(mo1.group(1))
+        l_ = len(mo1.group(1))
     else:
         if not text or not text.strip():
             return result
@@ -116,7 +116,7 @@ def parse_let_params(
 
     result.append((name, value))
 
-    text = text[l:].strip()
+    text = text[l_:].strip()
     if text:
         return parse_let_params(text, result, tag, **parms)
     else:

--- a/src/DocumentTemplate/DT_Raise.py
+++ b/src/DocumentTemplate/DT_Raise.py
@@ -57,14 +57,14 @@ class Raise(object):
         else:
             try:
                 t = expr.eval(md)
-            except:
+            except Exception:
                 t = convertExceptionType(self.__name__)
                 if t is None:
                     t = InvalidErrorTypeExpression
 
         try:
             v = render_blocks(self.section, md)
-        except:
+        except Exception:
             v = 'Invalid Error Value'
 
         # String Exceptions are deprecated on Python 2.5 and

--- a/src/DocumentTemplate/DT_String.py
+++ b/src/DocumentTemplate/DT_String.py
@@ -141,9 +141,10 @@ class String(object):
                 if name == 'else' and args:
                     # Waaaaaah! Have to special case else because of
                     # old else start tag usage. Waaaaaaah!
-                    l = len(args)
+                    l_ = len(args)
                     if not (args == sargs or
-                            args == sargs[:l] and sargs[l:l + 1] in ' \t\n'):
+                            args == sargs[:l_] and
+                            sargs[l_:l_ + 1] in ' \t\n'):
                         return tag, args, self.commands[name], None
 
                 return tag, args, None, name
@@ -169,21 +170,21 @@ class String(object):
             tagre = self.tagre()
         mo = tagre.search(text, start)
         while mo:
-            l = mo.start(0)
+            l_ = mo.start(0)
 
             try:
                 tag, args, command, coname = self._parseTag(mo)
             except ParseError as m:
-                self.parse_error(m[0], m[1], text, l)
+                self.parse_error(m[0], m[1], text, l_)
 
-            s = text[start:l]
+            s = text[start:l_]
             if s:
                 result.append(s)
-            start = l + len(tag)
+            start = l_ + len(tag)
 
             if hasattr(command, 'blockContinuations'):
                 start = self.parse_block(text, start, result, tagre,
-                                         tag, l, args, command)
+                                         tag, l_, args, command)
             else:
                 try:
                     if command is Var:
@@ -194,7 +195,7 @@ class String(object):
                         r = r.simple_form
                     result.append(r)
                 except ParseError as m:
-                    self.parse_error(m[0], tag, text, l)
+                    self.parse_error(m[0], tag, text, l_)
 
             mo = tagre.search(text, start)
 
@@ -228,28 +229,28 @@ class String(object):
             mo = tagre.search(text, start)
             if mo is None:
                 self.parse_error('No closing tag', stag, text, sloc)
-            l = mo.start(0)
+            l_ = mo.start(0)
 
             try:
                 tag, args, command, coname = self._parseTag(mo, scommand, sa)
             except ParseError as m:
-                self.parse_error(m[0], m[1], text, l)
+                self.parse_error(m[0], m[1], text, l_)
 
             if command:
-                start = l + len(tag)
+                start = l_ + len(tag)
                 if hasattr(command, 'blockContinuations'):
                     # New open tag.  Need to find closing tag.
-                    start = self.parse_close(text, start, tagre, tag, l,
+                    start = self.parse_close(text, start, tagre, tag, l_,
                                              command, args)
             else:
                 # Either a continuation tag or an end tag
                 section = self.SubTemplate(sname)
                 section._v_blocks = section.blocks = self.parse(
-                    text[:l], sstart)
+                    text[:l_], sstart)
                 section._v_cooked = None
                 blocks.append((tname, sargs, section))
 
-                start = self.skip_eol(text, l + len(tag))
+                start = self.skip_eol(text, l_ + len(tag))
 
                 if coname:
                     tname = coname
@@ -263,7 +264,7 @@ class String(object):
                             r = r.simple_form
                         result.append(r)
                     except ParseError as m:
-                        self.parse_error(m[0], stag, text, l)
+                        self.parse_error(m[0], stag, text, l_)
 
                     return start
 
@@ -273,18 +274,18 @@ class String(object):
             mo = tagre.search(text, start)
             if mo is None:
                 self.parse_error('No closing tag', stag, text, sloc)
-            l = mo.start(0)
+            l_ = mo.start(0)
 
             try:
                 tag, args, command, coname = self._parseTag(mo, scommand, sa)
             except ParseError as m:
-                self.parse_error(m[0], m[1], text, l)
+                self.parse_error(m[0], m[1], text, l_)
 
-            start = l + len(tag)
+            start = l_ + len(tag)
             if command:
                 if hasattr(command, 'blockContinuations'):
                     # New open tag.  Need to find closing tag.
-                    start = self.parse_close(text, start, tagre, tag, l,
+                    start = self.parse_close(text, start, tagre, tag, l_,
                                              command, args)
             elif not coname:
                 return start

--- a/src/DocumentTemplate/DT_Try.py
+++ b/src/DocumentTemplate/DT_Try.py
@@ -151,7 +151,7 @@ class Try(object):
             result = render_blocks(self.section, md)
         except DTReturn:
             raise
-        except:
+        except Exception:
             # but an error occurs.. save the info.
             t, v = sys.exc_info()[:2]
             if isinstance(t, str):

--- a/src/DocumentTemplate/DT_Util.py
+++ b/src/DocumentTemplate/DT_Util.py
@@ -414,14 +414,14 @@ def parse_params(text,
     if mo_p:
         name = mo_p.group(2).lower()
         value = mo_p.group(3)
-        l = len(mo_p.group(1))
+        l_ = len(mo_p.group(1))
     elif mo_q:
         name = mo_q.group(2).lower()
         value = mo_q.group(3)
-        l = len(mo_q.group(1))
+        l_ = len(mo_q.group(1))
     elif mo_unp:
         name = mo_unp.group(2)
-        l = len(mo_unp.group(1))
+        l_ = len(mo_unp.group(1))
         if result:
             if name in parms:
                 if parms[name] is None:
@@ -434,16 +434,16 @@ def parse_params(text,
                     'Invalid attribute name, "%s"' % name, tag)
         else:
             result[''] = name
-        return parse_params(text[l:], result, **parms)
+        return parse_params(text[l_:], result, **parms)
     elif mo_unq:
         name = mo_unq.group(2)
-        l = len(mo_unq.group(1))
+        l_ = len(mo_unq.group(1))
         if result:
             raise ParseError(
                 'Invalid attribute name, "%s"' % name, tag)
         else:
             result[''] = name
-        return parse_params(text[l:], result, **parms)
+        return parse_params(text[l_:], result, **parms)
     else:
         if not text or not text.strip():
             return result
@@ -461,7 +461,7 @@ def parse_params(text,
 
     result[name] = value
 
-    text = text[l:].strip()
+    text = text[l_:].strip()
     if text:
         return parse_params(text, result, **parms)
     else:

--- a/src/DocumentTemplate/DT_Util.py
+++ b/src/DocumentTemplate/DT_Util.py
@@ -59,7 +59,7 @@ def int_param(params, md, name, default=0, st=type('')):
     if v:
         try:
             v = int(v)
-        except:
+        except (TypeError, ValueError):
             v = md[v]
             if isinstance(v, str):
                 v = int(v)

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -266,7 +266,8 @@ class Var(object):
                             val = TaintedString(fmt % val)
                         else:
                             val = fmt % val
-                except:
+                except Exception:
+                    # Not clear which specific error has to be caught.
                     t, v = sys.exc_type, sys.exc_value
                     if hasattr(sys, 'exc_info'):
                         t, v = sys.exc_info()[:2]

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -328,14 +328,14 @@ class Var(object):
                     '<code>var</code> tag with a non-integer value.')
             if len(val) > size:
                 val = val[:size]
-                l = val.rfind(' ')
-                if l > size / 2:
-                    val = val[:l + 1]
+                l_ = val.rfind(' ')
+                if l_ > size / 2:
+                    val = val[:l_ + 1]
                 if 'etc' in args:
-                    l = args['etc']
+                    l_ = args['etc']
                 else:
-                    l = '...'
-                val = val + l
+                    l_ = '...'
+                val = val + l_
 
         if isinstance(val, TaintedString):
             val = val.quoted()
@@ -440,8 +440,8 @@ def thousands_commas(v, name='(Unknown name)', md={},
         s = ''
     mo = thou(v)
     while mo is not None:
-        l = mo.start(0)
-        v = v[:l + 1] + ',' + v[l + 1:]
+        l_ = mo.start(0)
+        v = v[:l_ + 1] + ',' + v[l_ + 1:]
         mo = thou(v)
     return v + s
 

--- a/src/DocumentTemplate/_DocumentTemplate.py
+++ b/src/DocumentTemplate/_DocumentTemplate.py
@@ -146,10 +146,10 @@ def render_blocks(blocks, md):
 
     render_blocks_(blocks, rendered, md)
 
-    l = len(rendered)
-    if l == 0:
+    l_ = len(rendered)
+    if l_ == 0:
         return ''
-    elif l == 1:
+    elif l_ == 1:
         return rendered[0]
     return join_unicode(rendered)
 
@@ -341,10 +341,10 @@ class TemplateDict(Base):
 
     def _pop(self, i=1):
         """_pop() -- Remove and return the last data source added"""
-        l = len(self._data)
-        i = l - i
-        r = self._data[l - 1]
-        self._data[i:l] = []
+        l_ = len(self._data)
+        i = l_ - i
+        r = self._data[l_ - 1]
+        self._data[i:l_] = []
         return r
 
     def _push(self, src):
@@ -423,8 +423,8 @@ class TemplateDict(Base):
         return key in self
 
     def __call__(self, *args, **kw):
-        l = len(args)
-        if l:
+        l_ = len(args)
+        if l_:
             r = type(self)()
             for arg in args:
                 r._push(arg)

--- a/src/DocumentTemplate/tests/testDTML.py
+++ b/src/DocumentTemplate/tests/testDTML.py
@@ -520,8 +520,8 @@ class RESTTests(DTMLTests):
         # The include: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assertTrue(source in result)
-        self.assertTrue(docutils_include_warning in result)
+        self.assertIn(source, result)
+        self.assertIn(docutils_include_warning, result)
 
     def test_fmt_reST_raw_directive_disabled(self):
         EXPECTED = '<h1>HELLO WORLD</h1>'
@@ -533,9 +533,9 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assertTrue(EXPECTED not in result)
-        self.assertTrue(escape(EXPECTED) in result)
-        self.assertTrue(docutils_raw_warning in result)
+        self.assertNotIn(EXPECTED, result)
+        self.assertIn(escape(EXPECTED), result)
+        self.assertIn(docutils_raw_warning, result)
 
     def test_fmt_reST_raw_directive_file_option_raises(self):
         source = '.. raw:: html\n  :file: inclusion.txt'
@@ -546,8 +546,8 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assertTrue(source in result)
-        self.assertTrue(docutils_raw_warning in result)
+        self.assertIn(source, result)
+        self.assertIn(docutils_raw_warning, result)
 
     def test_fmt_reST_raw_directive_url_option_raises(self):
         source = '.. raw:: html\n  :url: http://www.zope.org'
@@ -558,8 +558,8 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assertTrue(source in result)
-        self.assertTrue(docutils_raw_warning in result)
+        self.assertIn(source, result)
+        self.assertIn(docutils_raw_warning, result)
 
 
 def read_file(name):

--- a/src/DocumentTemplate/tests/testDTML.py
+++ b/src/DocumentTemplate/tests/testDTML.py
@@ -520,8 +520,8 @@ class RESTTests(DTMLTests):
         # The include: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assert_(source in result)
-        self.assert_(docutils_include_warning in result)
+        self.assertTrue(source in result)
+        self.assertTrue(docutils_include_warning in result)
 
     def test_fmt_reST_raw_directive_disabled(self):
         EXPECTED = '<h1>HELLO WORLD</h1>'
@@ -533,9 +533,9 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assert_(EXPECTED not in result)
-        self.assert_(escape(EXPECTED) in result)
-        self.assert_(docutils_raw_warning in result)
+        self.assertTrue(EXPECTED not in result)
+        self.assertTrue(escape(EXPECTED) in result)
+        self.assertTrue(docutils_raw_warning in result)
 
     def test_fmt_reST_raw_directive_file_option_raises(self):
         source = '.. raw:: html\n  :file: inclusion.txt'
@@ -546,8 +546,8 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assert_(source in result)
-        self.assert_(docutils_raw_warning in result)
+        self.assertTrue(source in result)
+        self.assertTrue(docutils_raw_warning in result)
 
     def test_fmt_reST_raw_directive_url_option_raises(self):
         source = '.. raw:: html\n  :url: http://www.zope.org'
@@ -558,8 +558,8 @@ class RESTTests(DTMLTests):
         # The raw: directive hasn't been rendered, it remains
         # verbatimly in the rendered output.  Instead a warning
         # message is presented:
-        self.assert_(source in result)
-        self.assert_(docutils_raw_warning in result)
+        self.assertTrue(source in result)
+        self.assertTrue(docutils_raw_warning in result)
 
 
 def read_file(name):

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -383,8 +383,6 @@ def tpRenderTABLE(self, id, root_url, url, state, substate, diff, data,
             if six.PY3:
                 s = s.decode('ASCII')
 
-            script = md['BASEPATH1']
-
             # Propagate extra args through tree.
             if 'urlparam' in args:
                 param = args['urlparam']

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -225,9 +225,9 @@ def tpRender(self, md, section, args,
 
         url = ''
         root = md['URL']
-        l = root.rfind('/')
-        if l >= 0:
-            root = root[l + 1:]
+        right_end = root.rfind('/')
+        if right_end >= 0:
+            root = root[right_end + 1:]
 
     treeData = {'tree-root-url': root,
                 'tree-colspan': colspan,
@@ -590,19 +590,19 @@ def apply_diff(state, diff, expand):
 def encode_seq(state):
     "Convert a sequence to an encoded string"
     state = compress(json.dumps(state))
-    l = len(state)
+    l_ = len(state)
 
-    if l > 57:
+    if l_ > 57:
         states = []
-        for i in range(0, l, 57):
+        for i in range(0, l_, 57):
             states.append(b2a_base64(state[i:i + 57])[:-1])
         state = b''.join(states)
     else:
         state = b2a_base64(state)[:-1]
 
-    l = state.find(b'=')
-    if l >= 0:
-        state = state[:l]
+    l_ = state.find(b'=')
+    if l_ >= 0:
+        state = state[:l_]
 
     state = state.translate(tplus)
     if six.PY3:
@@ -618,20 +618,20 @@ def encode_str(state):
     if not isinstance(state, bytes):
         raise ValueError("state should be bytes")
 
-    l = len(state)
+    l_ = len(state)
 
-    if l > 57:
+    if l_ > 57:
         states = []
-        for i in range(0, l, 57):
+        for i in range(0, l_, 57):
             states.append(b2a_base64(state[i:i + 57])[:-1])
         state = b''.join(states)
     else:
         state = b2a_base64(state)[:-1]
 
     # state is still bytes, but all in 'ascii' encoding.
-    l = state.find(b'=')
-    if l >= 0:
-        state = state[:l]
+    l_ = state.find(b'=')
+    if l_ >= 0:
+        state = state[:l_]
 
     state = state.translate(tplus)
     return state
@@ -643,27 +643,27 @@ def decode_seq(state):
         state = state.encode('ascii')
 
     state = state.translate(tminus)
-    l = len(state)
+    l_ = len(state)
 
-    if l > 76:
+    if l_ > 76:
         states = []
         j = 0
-        for i in range(l // 76):
+        for i in range(l_ // 76):
             k = j + 76
             states.append(a2b_base64(state[j:k]))
             j = k
 
-        if j < l:
+        if j < l_:
             state = state[j:]
-            l = len(state)
-            k = l % 4
+            l_ = len(state)
+            k = l_ % 4
             if k:
                 state = state + b'=' * (4 - k)
             states.append(a2b_base64(state))
         state = b''.join(states)
     else:
-        l = len(state)
-        k = l % 4
+        l_ = len(state)
+        k = l_ % 4
         if k:
             state = state + b'=' * (4 - k)
         state = a2b_base64(state)


### PR DESCRIPTION
The renaming of the short variable `l` is probably debatable, but we have actually statements like `i = l -i`.