### PR TITLE
Use UTF 8 instead of Latin-1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changelog
 2.13.5 (unreleased)
 -------------------
 
+- Use 'utf-8' to decode non-unicode strings instead of 'latin-1'.
 
 2.13.4 (2017-02-15)
 -------------------

--- a/src/DocumentTemplate/cDocumentTemplate.c
+++ b/src/DocumentTemplate/cDocumentTemplate.c
@@ -960,7 +960,7 @@ static struct PyMethodDef Module_Level__methods[] = {
    "join a list of plain strings into a single plain string,\n"
    "a list of unicode strings into a single unicode strings,\n"
    "or a list containing a mix into a single unicode string with\n"
-   "the plain strings converted from latin-1"},
+   "the plain strings converted from UTF-8"},
   {"safe_callable", (PyCFunction)safe_callable,	METH_VARARGS,
    "callable() with a workaround for a problem with ExtensionClasses\n"
    "and __call__()."},

--- a/src/DocumentTemplate/cDocumentTemplate.c
+++ b/src/DocumentTemplate/cDocumentTemplate.c
@@ -925,7 +925,7 @@ _join_unicode(PyObject *prejoin)
             PyObject *item = PyList_GetItem(list,i);
             if(PyString_Check(item))
             {
-                PyObject *unicode = PyUnicode_DecodeLatin1(PyString_AsString(item),PyString_Size(item),NULL);
+                PyObject *unicode = PyUnicode_DecodeUTF8(PyString_AsString(item),PyString_Size(item),NULL);
                 if(unicode)
                 {
                     PyList_SetItem(list,i,unicode);

--- a/src/DocumentTemplate/pDocumentTemplate.py
+++ b/src/DocumentTemplate/pDocumentTemplate.py
@@ -247,9 +247,9 @@ def join_unicode(rendered):
         return ''.join(rendered)
     except UnicodeError:
         # A mix of unicode string and non-ascii plain strings.
-        # Fix up the list, treating normal strings as latin-1
+        # Fix up the list, treating normal strings as UTF-8
         rendered = list(rendered)
         for i in range(len(rendered)):
             if type(rendered[i]) is StringType:
-                rendered[i] = unicode(rendered[i],'latin-1')
+                rendered[i] = unicode(rendered[i],'utf-8')
         return u''.join(rendered)

--- a/src/DocumentTemplate/tests/testDTMLUnicode.py
+++ b/src/DocumentTemplate/tests/testDTMLUnicode.py
@@ -55,25 +55,25 @@ class DTMLUnicodeTests (unittest.TestCase):
     def testUB(self):
         html=self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'hello\xc8'
-        res = html(a=u'hello',b=chr(200))
+        res = html(a=u'hello',b='\xc3\x88')
         assert res == expected, `res`
 
     def testUB2(self):
         html=self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'\u07d0\xc8'
-        res = html(a=unichr(2000),b=chr(200))
+        res = html(a=unichr(2000),b='\xc3\x88')
         assert res == expected, `res`
 
     def testUnicodeStr(self):
         html=self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'\u07d0\xc8'
-        res = html(a=force_str(unichr(2000)),b=chr(200))
+        res = html(a=force_str(unichr(2000)),b='\xc3\x88')
         assert res == expected, `res`
 
     def testUqB(self):
         html=self.doc_class('<dtml-var a html_quote><dtml-var b>')
         expected = u'he&gt;llo\xc8'
-        res = html(a=u'he>llo',b=chr(200))
+        res = html(a=u'he>llo',b='\xc3\x88')
         assert res == expected, `res`
 
     def testSize(self):


### PR DESCRIPTION
This changes the hard-coded decoding of non-unicode strings to UTF-8.