### PR TITLE
Use UTF-8 instead of Latin-1 encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 3.0b4 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Use 'utf-8' to decode non-unicode strings instead of 'latin-1'.
 
 3.0b3 (2018-04-18)
 ------------------

--- a/src/DocumentTemplate/_DocumentTemplate.py
+++ b/src/DocumentTemplate/_DocumentTemplate.py
@@ -127,17 +127,17 @@ def join_unicode(rendered):
     """join a list of plain strings into a single plain string,
     a list of unicode strings into a single unicode strings,
     or a list containing a mix into a single unicode string with
-    the plain strings converted from latin-1
+    the plain strings converted from UTF-8
     """
     try:
         return ''.join(rendered)
     except UnicodeError:
         # A mix of unicode string and non-ascii plain strings.
-        # Fix up the list, treating normal strings as latin-1
+        # Fix up the list, treating normal strings as UTF-8
         rendered = list(rendered)
         for i in range(len(rendered)):
             if isinstance(rendered[i], str):
-                rendered[i] = unicode(rendered[i], 'latin-1')
+                rendered[i] = unicode(rendered[i], 'utf-8')
         return u''.join(rendered)
 
 

--- a/src/DocumentTemplate/tests/testDTMLUnicode.py
+++ b/src/DocumentTemplate/tests/testDTMLUnicode.py
@@ -58,37 +58,37 @@ class DTMLUnicodeTests(unittest.TestCase):
     def testAB(self):
         html = self.doc_class('<dtml-var a><dtml-var b>')
         expected = 'hello\xc8'
-        res = html(a='hello', b=chr(200))
+        res = html(a='hello', b='\xc8')
         self.assertEqual(res, expected)
 
     def testUB(self):
         html = self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'hello\xc8'
-        res = html(a=u'hello', b=chr(200))
+        res = html(a=u'hello', b='\xc3\x88')
         self.assertEqual(res, expected)
 
     def testUB2(self):
         html = self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'\u07d0\xc8'
-        res = html(a=unichr(2000), b=chr(200))
+        res = html(a=unichr(2000), b='\xc3\x88')
         self.assertEqual(res, expected)
 
     def testUnicodeStr(self):
         html = self.doc_class('<dtml-var a><dtml-var b>')
         expected = u'\u07d0\xc8'
-        res = html(a=force_str(unichr(2000)), b=chr(200))
+        res = html(a=force_str(unichr(2000)), b='\xc3\x88')
         self.assertEqual(res, expected)
 
     def testUqB(self):
         html = self.doc_class('<dtml-var a html_quote><dtml-var b>')
         expected = u'he&gt;llo\xc8'
-        res = html(a=u'he>llo', b=chr(200))
+        res = html(a=u'he>llo', b='\xc3\x88')
         self.assertEqual(res, expected)
 
     def testSize(self):
         if six.PY3:
             html = self.doc_class('<dtml-var "_.chr(200)*4" size=2>')
-            expected = chr(200) * 2 + '...'
+            expected = '\xc3\x88' * 2 + '...'
         else:
             html = self.doc_class('<dtml-var "_.unichr(200)*4" size=2>')
             expected = unichr(200) * 2 + '...'


### PR DESCRIPTION
This changes the hard-coded decoding of non-unicode strings to UTF-8.

See also #20 (against 2.13).
Superseded by #23.