### PR TITLE
InstanceDict: Fix difference between implementation in C resp. Python 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 3.0b4 (unreleased)
 ------------------
 
+- Fix a regression in the Python implementation differing from the C
+  implementation in ``DocumentTemplate.DT_Util.InstanceDict``.
+  `#24 <https://github.com/zopefoundation/DocumentTemplate/pull/24>`_
+
 - Improve compatibility with flake8.
+
 - Update deprecated assert method calls.
 
 

--- a/src/DocumentTemplate/_DocumentTemplate.py
+++ b/src/DocumentTemplate/_DocumentTemplate.py
@@ -109,6 +109,7 @@ import types
 
 from Acquisition import aq_base
 from ExtensionClass import Base
+import Acquisition
 
 from DocumentTemplate.html_quote import html_quote
 from DocumentTemplate.ustr import ustr
@@ -305,7 +306,7 @@ class InstanceDict(Base):
             get = getattr
 
         try:
-            result = get(self.inst, key)
+            result = get(Acquisition.aq_inner(self.inst), key)
         except AttributeError:
             raise KeyError(key)
 

--- a/src/DocumentTemplate/_DocumentTemplate.py
+++ b/src/DocumentTemplate/_DocumentTemplate.py
@@ -108,8 +108,8 @@ import sys
 import types
 
 from Acquisition import aq_base
+from Acquisition import aq_inner
 from ExtensionClass import Base
-import Acquisition
 
 from DocumentTemplate.html_quote import html_quote
 from DocumentTemplate.ustr import ustr
@@ -306,7 +306,7 @@ class InstanceDict(Base):
             get = getattr
 
         try:
-            result = get(Acquisition.aq_inner(self.inst), key)
+            result = get(aq_inner(self.inst), key)
         except AttributeError:
             raise KeyError(key)
 

--- a/src/DocumentTemplate/tests/test_DocumentTemplate.py
+++ b/src/DocumentTemplate/tests/test_DocumentTemplate.py
@@ -1,0 +1,34 @@
+import unittest
+
+
+class InstanceDictTests(unittest.TestCase):
+    """Testing .._DocumentTemplate.InstanceDict."""
+
+    def test_getitem(self):
+        """The acquisition chain of the object a got method is bound to ...
+
+        does not contain the InstanceDict instance itself.
+
+        This is a test for the fix of the regression described in
+        https://github.com/zopefoundation/Zope/issues/292
+        """
+        from DocumentTemplate.DT_Util import InstanceDict
+        import Acquisition
+
+        class Item(Acquisition.Implicit):
+            """Class modelling the here necessary parts of OFS.SimpleItem."""
+
+            def __init__(self, id):
+                self.id = id
+
+            def __repr__(self):
+                return '<Item id={0.id!r}>'.format(self)
+
+            def method1(self):
+                pass
+
+        inst = Item('a').__of__(Item('b'))
+        i_dict = InstanceDict(inst, {}, getattr)
+
+        for element in Acquisition.aq_chain(i_dict['method1'].__self__):
+            self.assertNotIsInstance(element, InstanceDict)

--- a/src/DocumentTemplate/tests/test_DocumentTemplate.py
+++ b/src/DocumentTemplate/tests/test_DocumentTemplate.py
@@ -5,13 +5,12 @@ class InstanceDictTests(unittest.TestCase):
     """Testing .._DocumentTemplate.InstanceDict."""
 
     def test_getitem(self):
-        """The acquisition chain of the object a got method is bound to ...
+        # The acquisition chain of the object a got method is bound to
+        # does not contain the InstanceDict instance itself.
 
-        does not contain the InstanceDict instance itself.
+        # This is a test for the fix of the regression described in
+        # https://github.com/zopefoundation/Zope/issues/292
 
-        This is a test for the fix of the regression described in
-        https://github.com/zopefoundation/Zope/issues/292
-        """
         from DocumentTemplate.DT_Util import InstanceDict
         import Acquisition
 


### PR DESCRIPTION
There is a difference between the (former) C implementation of `DocumentTemplate.DT_Util.InstanceDict` and the Python one. This causes that user defined roles created on an object do not show up on its child objects in the `manage_access` view.

The following script shows the difference: (also attached here: [292.py.txt](https://github.com/zopefoundation/DocumentTemplate/files/2175572/292.py.txt))

```python
import Acquisition
import DocumentTemplate.DT_Util
from Acquisition import Implicit


class C(Implicit):

    def __init__(self, id):
        self.id = id

    def __repr__(self):
        return '<C id={0.id!r}>'.format(self)

    def method1(self):
        pass

inst = C('a').__of__(C('b'))
id = DocumentTemplate.DT_Util.InstanceDict(inst, {}, getattr)

print(Acquisition.aq_chain(id['method1'].__self__))
```

On a Zope 2.13 installation it prints: ```[<C id='a'>, <C id='b'>]``` (This uses the C implementation. The Python one on the 2.13 branch has the same problem as on master, see https://github.com/zopefoundation/DocumentTemplate/blob/2.13/src/DocumentTemplate/pDocumentTemplate.py#L88)

On a Zope 4.0b5 installation it prints: ```[<C id='a'>, InstanceDict(<C id='a'>)]```

This aq_chain makes that `valid_roles()` (https://github.com/zopefoundation/AccessControl/blob/master/src/AccessControl/rolemanager.py#L389-L397) takes the `InstanceDict` as the parent of an object thus missing the roles defined on the actual parent.

This PR makes the C and Python implementations to behave the same in this point.

Fixes zopefoundation/Zope#292.
