### PR TITLE
Work around explosion when objects don't have a _p_oid value or it is…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.0b5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Stabilized TreeTag rendering for objects without ``_p_oid`` values.
 
 
 3.0b4 (2018-07-12)

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -268,7 +268,7 @@ def tpRenderTABLE(self, id, root_url, url, state, substate, diff, data,
     ptreeData['tree-item-url'] = url
     ptreeData['tree-level'] = level
     ptreeData['tree-item-expanded'] = 0
-    
+
     output = data.append
 
     items = None
@@ -712,7 +712,7 @@ def tpValuesIds(self, get_items, args,
             try:
                 if get_items(item):
                     id = extract_id(item, args['id'])
-                    
+
                     e = tpValuesIds(item, get_items, args)
                     if e:
                         id = [id, e]
@@ -724,6 +724,7 @@ def tpValuesIds(self, get_items, args,
     except Exception:
         pass
     return r
+
 
 def extract_id(item, idattr):
     if hasattr(item, idattr):


### PR DESCRIPTION
… none. Mitigates #26

This still has the problem that CMFCore DirectoryViews are not expandable, but at least they don't crash anymore.