### PR TITLE
Fix regression in DT_Util.InstanceDict.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0b6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix regression in ``.DT_Util.InstanceDict`` which broke the acquisition
+  chain of the item it wraps.
+  (`#38 <https://github.com/zopefoundation/DocumentTemplate/issues/38>`_)
 
 
 3.0b5 (2018-10-05)

--- a/src/DocumentTemplate/_DocumentTemplate.py
+++ b/src/DocumentTemplate/_DocumentTemplate.py
@@ -108,7 +108,6 @@ import sys
 import types
 
 from Acquisition import aq_base
-from Acquisition import aq_inner
 from ExtensionClass import Base
 
 from DocumentTemplate.html_quote import html_quote
@@ -267,7 +266,7 @@ def safe_callable(ob):
     return callable(ob)
 
 
-class InstanceDict(Base):
+class InstanceDict(object):
     """"""
 
     guarded_getattr = None
@@ -306,7 +305,7 @@ class InstanceDict(Base):
             get = getattr
 
         try:
-            result = get(aq_inner(self.inst), key)
+            result = get(self.inst, key)
         except AttributeError:
             raise KeyError(key)
 

--- a/src/DocumentTemplate/tests/test_DocumentTemplate.py
+++ b/src/DocumentTemplate/tests/test_DocumentTemplate.py
@@ -1,4 +1,18 @@
 import unittest
+import Acquisition
+
+
+class Item(Acquisition.Implicit):
+    """Class modelling the here necessary parts of OFS.SimpleItem."""
+
+    def __init__(self, id):
+        self.id = id
+
+    def __repr__(self):
+        return '<Item id={0.id!r}>'.format(self)
+
+    def method1(self):
+        pass
 
 
 class InstanceDictTests(unittest.TestCase):
@@ -12,22 +26,23 @@ class InstanceDictTests(unittest.TestCase):
         # https://github.com/zopefoundation/Zope/issues/292
 
         from DocumentTemplate.DT_Util import InstanceDict
-        import Acquisition
-
-        class Item(Acquisition.Implicit):
-            """Class modelling the here necessary parts of OFS.SimpleItem."""
-
-            def __init__(self, id):
-                self.id = id
-
-            def __repr__(self):
-                return '<Item id={0.id!r}>'.format(self)
-
-            def method1(self):
-                pass
 
         inst = Item('a').__of__(Item('b'))
         i_dict = InstanceDict(inst, {}, getattr)
 
         for element in Acquisition.aq_chain(i_dict['method1'].__self__):
             self.assertNotIsInstance(element, InstanceDict)
+
+    def test_getitem_2(self):
+        # It does not break the acquisition chain of stored objects.
+
+        from DocumentTemplate.DT_Util import InstanceDict
+
+        main = Item('main')
+        main.sub = Item('sub')
+        side = Item('side')
+        side.here = Item('here')
+
+        path = side.here.__of__(main)
+        i_dict = InstanceDict(path, {}, getattr)
+        self.assertEqual(main.sub, i_dict['sub'])


### PR DESCRIPTION
It broke the acquisition chain of the item it wraps.
This is fix fixes in #24 so both use cases are fixed.

Fixes #38.
Closes #39.