### PR TITLE
Escape more characters in sql_quote. [master]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ default.profraw
 develop-eggs/
 eggs/
 pip-selfcheck.json
+pyvenv.cfg

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 3.1 (unreleased)
 ----------------
 
+Bug fixes
++++++++++
+
+- Escape more characters in ``sql_quote``.  Taken over from PloneHotfix20200121.
+
 
 3.1b2 (2019-05-16)
 ------------------

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -514,8 +514,8 @@ def structured_text(v, name='(Unknown name)', md={}):
 
 # Searching and replacing a byte in text, or text in bytes,
 # may give various errors on Python 2 or 3.  So we make separate functions
-REMOVE_BYTES = (b'\x00', b'\x1a', b'\n', b'\r')
-REMOVE_TEXT = (u'\x00', u'\x1a', u'\n', u'\r')
+REMOVE_BYTES = (b'\x00', b'\x1a', b'\r')
+REMOVE_TEXT = (u'\x00', u'\x1a', u'\r')
 DOUBLE_BYTES = (b"'", b'\\')
 DOUBLE_TEXT = (u"'", u'\\')
 ESCAPE_BYTES = (b'"',)

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -546,7 +546,7 @@ def text_sql_quote(v):
         v = v.replace(char, char * 2)
     # Backslash-escape untrusted characters to make them harmless.
     for char in ESCAPE_TEXT:
-        v = v.replace(char, '\\%s' % char)
+        v = v.replace(char, u'\\%s' % char)
     return v
 
 

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -514,35 +514,39 @@ def structured_text(v, name='(Unknown name)', md={}):
 
 # Searching and replacing a byte in text, or text in bytes,
 # may give various errors on Python 2 or 3.  So we make separate functions
-UNTRUSTED_BYTES = (b"'", b'"', b"\\")
-UNTRUSTED_TEXT = (u"'", u'"', u"\\")
-BAD_BYTES = (b"\x00",)
-BAD_TEXT = (u"\x00",)
+REMOVE_BYTES = (b'\x00', b'\x1a', b'\n', b'\r')
+REMOVE_TEXT = (u'\x00', u'\x1a', u'\n', u'\r')
+DOUBLE_BYTES = (b"'", b'\\')
+DOUBLE_TEXT = (u"'", u'\\')
+ESCAPE_BYTES = (b'"',)
+ESCAPE_TEXT = (u'"',)
 
 
 def bytes_sql_quote(v):
     # Helper function for sql_quote, handling only bytes.
     # Remove bad characters.
-    for char in BAD_BYTES:
-        if char in v:
-            v = v.replace(char, b"")
+    for char in REMOVE_BYTES:
+        v = v.replace(char, b'')
     # Double untrusted characters to make them harmless.
-    for char in UNTRUSTED_BYTES:
-        if char in v:
-            v = v.replace(char, char * 2)
+    for char in DOUBLE_BYTES:
+        v = v.replace(char, char * 2)
+    # Backslash-escape untrusted characters to make them harmless.
+    for char in ESCAPE_BYTES:
+        v = v.replace(char, b'\\%s' % char)
     return v
 
 
 def text_sql_quote(v):
     # Helper function for sql_quote, handling only text.
     # Remove bad characters.
-    for char in BAD_TEXT:
-        if char in v:
-            v = v.replace(char, u"")
+    for char in REMOVE_TEXT:
+        v = v.replace(char, u'')
     # Double untrusted characters to make them harmless.
-    for char in UNTRUSTED_TEXT:
-        if char in v:
-            v = v.replace(char, char * 2)
+    for char in DOUBLE_TEXT:
+        v = v.replace(char, char * 2)
+    # Backslash-escape untrusted characters to make them harmless.
+    for char in ESCAPE_TEXT:
+        v = v.replace(char, '\\%s' % char)
     return v
 
 

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -94,3 +94,65 @@ class TestUrlQuoting(unittest.TestCase):
             url_unquote_plus(quoted_unicode_value), unicode_value)
         self.assertEqual(
             url_unquote_plus(quoted_utf8_value), utf8_value)
+
+    def test_bytes_sql_quote(self):
+        from DocumentTemplate.DT_Var import bytes_sql_quote
+        self.assertEqual(bytes_sql_quote(b""), b"")
+        self.assertEqual(bytes_sql_quote(b"a"), b"a")
+
+        self.assertEqual(bytes_sql_quote(b"Can't"), b"Can''t")
+        self.assertEqual(bytes_sql_quote(b"Can\'t"), b"Can''t")
+        self.assertEqual(bytes_sql_quote(br"Can\'t"), b"Can\\\\''t")
+
+        self.assertEqual(bytes_sql_quote(b"Can\\ I?"), b"Can\\\\ I?")
+        self.assertEqual(bytes_sql_quote(br"Can\ I?"), b"Can\\\\ I?")
+
+        self.assertEqual(bytes_sql_quote(b'Just say "Hello"'), b'Just say ""Hello""')
+
+        self.assertEqual(bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
+        self.assertEqual(bytes_sql_quote(b'\x00Hello\x00\x00World\x00'), b'HelloWorld')
+
+    def test_text_sql_quote(self):
+        from DocumentTemplate.DT_Var import text_sql_quote
+        self.assertEqual(text_sql_quote(u""), u"")
+        self.assertEqual(text_sql_quote(u"a"), u"a")
+
+        self.assertEqual(text_sql_quote(u"Can't"), u"Can''t")
+        self.assertEqual(text_sql_quote(u"Can\'t"), u"Can''t")
+        # SyntaxError on Python 3.
+        # self.assertEqual(text_sql_quote(ur"Can\'t"), u"Can\\\\''t")
+
+        self.assertEqual(text_sql_quote(u"Can\\ I?"), u"Can\\\\ I?")
+        # SyntaxError on Python 3.
+        # self.assertEqual(text_sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
+
+        self.assertEqual(text_sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+
+        self.assertEqual(text_sql_quote(u'Hello\x00World'), u'HelloWorld')
+        self.assertEqual(text_sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+
+    def test_sql_quote(self):
+        from DocumentTemplate.DT_Var import sql_quote
+        self.assertEqual(sql_quote(u""), u"")
+        self.assertEqual(sql_quote(u"a"), u"a")
+        self.assertEqual(sql_quote(b"a"), b"a")
+
+        self.assertEqual(sql_quote(u"Can't"), u"Can''t")
+        self.assertEqual(sql_quote(u"Can\'t"), u"Can''t")
+        # SyntaxError on Python 3.
+        # self.assertEqual(sql_quote(ur"Can\'t"), u"Can\\\\''t")
+
+        self.assertEqual(sql_quote(u"Can\\ I?"), u"Can\\\\ I?")
+        # SyntaxError on Python 3.
+        # self.assertEqual(sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
+
+        self.assertEqual(sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+
+        self.assertEqual(sql_quote(u'Hello\x00World'), u'HelloWorld')
+        self.assertEqual(sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+
+        self.assertEqual(sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+
+        self.assertEqual(u"\xea".encode("utf-8"), b"\xc3\xaa")
+        self.assertEqual(sql_quote(u"\xea'"), u"\xea''")
+        self.assertEqual(sql_quote(b"\xc3\xaa'"), b"\xc3\xaa''")

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -115,6 +115,11 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(
             bytes_sql_quote(b'\x00Hello\x00\x00World\x00'), b'HelloWorld')
 
+        self.assertEqual(
+            bytes_sql_quote(b"carriage\rreturn"), b"carriagereturn")
+        self.assertEqual(bytes_sql_quote(b"line\nbreak"), b"line\nbreak")
+        self.assertEqual(bytes_sql_quote(b"tab\t"), b"tab\t")
+
     def test_text_sql_quote(self):
         from DocumentTemplate.DT_Var import text_sql_quote
         self.assertEqual(text_sql_quote(u""), u"")
@@ -136,6 +141,11 @@ class TestUrlQuoting(unittest.TestCase):
             text_sql_quote(u'Hello\x00World'), u'HelloWorld')
         self.assertEqual(
             text_sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+
+        self.assertEqual(
+            text_sql_quote(u"carriage\rreturn"), u"carriagereturn")
+        self.assertEqual(text_sql_quote(u"line\nbreak"), u"line\nbreak")
+        self.assertEqual(text_sql_quote(u"tab\t"), u"tab\t")
 
     def test_sql_quote(self):
         from DocumentTemplate.DT_Var import sql_quote
@@ -166,3 +176,10 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(u"\xea".encode("utf-8"), b"\xc3\xaa")
         self.assertEqual(sql_quote(u"\xea'"), u"\xea''")
         self.assertEqual(sql_quote(b"\xc3\xaa'"), b"\xc3\xaa''")
+
+        self.assertEqual(
+            sql_quote(b"carriage\rreturn"), b"carriagereturn")
+        self.assertEqual(
+            sql_quote(u"carriage\rreturn"), u"carriagereturn")
+        self.assertEqual(sql_quote(u"line\nbreak"), u"line\nbreak")
+        self.assertEqual(sql_quote(u"tab\t"), u"tab\t")

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -108,7 +108,7 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(bytes_sql_quote(br"Can\ I?"), b"Can\\\\ I?")
 
         self.assertEqual(
-            bytes_sql_quote(b'Just say "Hello"'), b'Just say ""Hello""')
+            bytes_sql_quote(b'Just say "Hello"'), b'Just say \\"Hello\\"')
 
         self.assertEqual(
             bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
@@ -130,7 +130,7 @@ class TestUrlQuoting(unittest.TestCase):
         # self.assertEqual(text_sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
         self.assertEqual(
-            text_sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+            text_sql_quote(u'Just say "Hello"'), u'Just say \\"Hello\\"')
 
         self.assertEqual(
             text_sql_quote(u'Hello\x00World'), u'HelloWorld')
@@ -153,7 +153,7 @@ class TestUrlQuoting(unittest.TestCase):
         # self.assertEqual(sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
         self.assertEqual(
-            sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+            sql_quote(u'Just say "Hello"'), u'Just say \\"Hello\\"')
 
         self.assertEqual(
             sql_quote(u'Hello\x00World'), u'HelloWorld')

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -107,10 +107,13 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(bytes_sql_quote(b"Can\\ I?"), b"Can\\\\ I?")
         self.assertEqual(bytes_sql_quote(br"Can\ I?"), b"Can\\\\ I?")
 
-        self.assertEqual(bytes_sql_quote(b'Just say "Hello"'), b'Just say ""Hello""')
+        self.assertEqual(
+            bytes_sql_quote(b'Just say "Hello"'), b'Just say ""Hello""')
 
-        self.assertEqual(bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
-        self.assertEqual(bytes_sql_quote(b'\x00Hello\x00\x00World\x00'), b'HelloWorld')
+        self.assertEqual(
+            bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
+        self.assertEqual(
+            bytes_sql_quote(b'\x00Hello\x00\x00World\x00'), b'HelloWorld')
 
     def test_text_sql_quote(self):
         from DocumentTemplate.DT_Var import text_sql_quote
@@ -126,10 +129,13 @@ class TestUrlQuoting(unittest.TestCase):
         # SyntaxError on Python 3.
         # self.assertEqual(text_sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
-        self.assertEqual(text_sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+        self.assertEqual(
+            text_sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
 
-        self.assertEqual(text_sql_quote(u'Hello\x00World'), u'HelloWorld')
-        self.assertEqual(text_sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+        self.assertEqual(
+            text_sql_quote(u'Hello\x00World'), u'HelloWorld')
+        self.assertEqual(
+            text_sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
 
     def test_sql_quote(self):
         from DocumentTemplate.DT_Var import sql_quote
@@ -146,12 +152,16 @@ class TestUrlQuoting(unittest.TestCase):
         # SyntaxError on Python 3.
         # self.assertEqual(sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
-        self.assertEqual(sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
+        self.assertEqual(
+            sql_quote(u'Just say "Hello"'), u'Just say ""Hello""')
 
-        self.assertEqual(sql_quote(u'Hello\x00World'), u'HelloWorld')
-        self.assertEqual(sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+        self.assertEqual(
+            sql_quote(u'Hello\x00World'), u'HelloWorld')
+        self.assertEqual(
+            sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
 
-        self.assertEqual(sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
+        self.assertEqual(
+            sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
 
         self.assertEqual(u"\xea".encode("utf-8"), b"\xc3\xaa")
         self.assertEqual(sql_quote(u"\xea'"), u"\xea''")


### PR DESCRIPTION
Taken over from PloneHotfix20200121.

For inspiration on escaping special characters in SQL, see [wikipedia](https://en.wikipedia.org/wiki/SQL_injection#Escaping). The approach there adds backslashes. Instead, we double some characters (which the original code did for single quotes), and remove another.
I am not actually sure which would be best, and which may have unintended consequences. I wonder if double quotes will end up twice in the database with our approach. I have not checked yet.

Anyway, with this PR the code will be the same as in the hotfix.

I intend to make a PR for the 2.13 branch as well, but let's first get this one accepted or adapted.