### PR TITLE
no longer escape double quotes in ``sql_quote`` - it breaks Postgres

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 3.2 (unreleased)
 ----------------
 
+- no longer escape double quotes in ``sql_quote`` - that breaks PostgreSQL
+  (`#48 <https://github.com/zopefoundation/DocumentTemplate/issues/48>`_)
+
 - Added `DeprecationWarnings` for all deprecated files and names
+  (`#42 <https://github.com/zopefoundation/DocumentTemplate/issues/42>`)
 
 - Import sorting done like Zope itself
 

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -524,8 +524,6 @@ REMOVE_BYTES = (b'\x00', b'\x1a', b'\r')
 REMOVE_TEXT = (u'\x00', u'\x1a', u'\r')
 DOUBLE_BYTES = (b"'", b'\\')
 DOUBLE_TEXT = (u"'", u'\\')
-ESCAPE_BYTES = (b'"',)
-ESCAPE_TEXT = (u'"',)
 
 
 def bytes_sql_quote(v):
@@ -536,9 +534,6 @@ def bytes_sql_quote(v):
     # Double untrusted characters to make them harmless.
     for char in DOUBLE_BYTES:
         v = v.replace(char, char * 2)
-    # Backslash-escape untrusted characters to make them harmless.
-    for char in ESCAPE_BYTES:
-        v = v.replace(char, b'\\%s' % char)
     return v
 
 
@@ -550,9 +545,6 @@ def text_sql_quote(v):
     # Double untrusted characters to make them harmless.
     for char in DOUBLE_TEXT:
         v = v.replace(char, char * 2)
-    # Backslash-escape untrusted characters to make them harmless.
-    for char in ESCAPE_TEXT:
-        v = v.replace(char, u'\\%s' % char)
     return v
 
 

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -108,7 +108,7 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(bytes_sql_quote(br"Can\ I?"), b"Can\\\\ I?")
 
         self.assertEqual(
-            bytes_sql_quote(b'Just say "Hello"'), b'Just say \\"Hello\\"')
+            bytes_sql_quote(b'Just say "Hello"'), b'Just say "Hello"')
 
         self.assertEqual(
             bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
@@ -135,7 +135,7 @@ class TestUrlQuoting(unittest.TestCase):
         # self.assertEqual(text_sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
         self.assertEqual(
-            text_sql_quote(u'Just say "Hello"'), u'Just say \\"Hello\\"')
+            text_sql_quote(u'Just say "Hello"'), u'Just say "Hello"')
 
         self.assertEqual(
             text_sql_quote(u'Hello\x00World'), u'HelloWorld')
@@ -163,7 +163,7 @@ class TestUrlQuoting(unittest.TestCase):
         # self.assertEqual(sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
 
         self.assertEqual(
-            sql_quote(u'Just say "Hello"'), u'Just say \\"Hello\\"')
+            sql_quote(u'Just say "Hello"'), u'Just say "Hello"')
 
         self.assertEqual(
             sql_quote(u'Hello\x00World'), u'HelloWorld')


### PR DESCRIPTION
Fixes #48 

This reverts a change I had added to #46, which turned out to be too aggressive. @mauritsvanrees please take a look and let me know what you think so I can make a new DocumentTemplate release.