### PR TITLE
Restore `sql_quote` behavior of always returning native strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.3 (unreleased)
 ----------------
 
+- Restore ``sql_quote`` behavior of always returning native strings
+  (`#54 <https://github.com/zopefoundation/DocumentTemplate/issues/54>`_)
+
 
 3.2.3 (2020-05-28)
 ------------------

--- a/src/DocumentTemplate/DT_Var.py
+++ b/src/DocumentTemplate/DT_Var.py
@@ -518,45 +518,26 @@ def structured_text(v, name='(Unknown name)', md={}):
     return HTML()(doc, level, header=False)
 
 
-# Searching and replacing a byte in text, or text in bytes,
-# may give various errors on Python 2 or 3.  So we make separate functions
-REMOVE_BYTES = (b'\x00', b'\x1a', b'\r')
-REMOVE_TEXT = (u'\x00', u'\x1a', u'\r')
-DOUBLE_BYTES = (b"'",)
-DOUBLE_TEXT = (u"'",)
-
-
-def bytes_sql_quote(v):
-    # Helper function for sql_quote, handling only bytes.
-    # Remove bad characters.
-    for char in REMOVE_BYTES:
-        v = v.replace(char, b'')
-    # Double untrusted characters to make them harmless.
-    for char in DOUBLE_BYTES:
-        v = v.replace(char, char * 2)
-    return v
-
-
-def text_sql_quote(v):
-    # Helper function for sql_quote, handling only text.
-    # Remove bad characters.
-    for char in REMOVE_TEXT:
-        v = v.replace(char, u'')
-    # Double untrusted characters to make them harmless.
-    for char in DOUBLE_TEXT:
-        v = v.replace(char, char * 2)
-    return v
-
-
 def sql_quote(v, name='(Unknown name)', md={}):
     """Quote single quotes in a string by doubling them.
 
     This is needed to securely insert values into sql
     string literals in templates that generate sql.
     """
-    if isinstance(v, bytes):
-        return bytes_sql_quote(v)
-    return text_sql_quote(v)
+    if six.PY3 and isinstance(v, bytes):
+        v = v.decode('UTF-8')
+    elif six.PY2 and not isinstance(v, bytes):
+        v = v.encode('UTF-8')
+
+    # Remove bad characters
+    for char in ('\x00', '\x1a', '\r'):
+        v = v.replace(char, '')
+
+    # Double untrusted characters to make them harmless.
+    for char in ("'",):
+        v = v.replace(char, char * 2)
+
+    return v
 
 
 special_formats = {

--- a/src/DocumentTemplate/tests/testDTML.py
+++ b/src/DocumentTemplate/tests/testDTML.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+import six
+
 from ..html_quote import html_quote
 
 
@@ -267,6 +269,26 @@ class DTMLTests(unittest.TestCase):
         expected = 'http://www.zope.org?a=b 123'
         self.assertEqual(html1(), expected)
         self.assertEqual(html2(), expected)
+
+    def test_sql_quote(self):
+        html = self.doc_class('<dtml-var x sql_quote>')
+        special = u'\xae'
+
+        self.assertEqual(html(x=u'x'), u'x')
+        self.assertEqual(html(x=b'x'), u'x')
+        self.assertEqual(html(x=u"Moe's Bar"), u"Moe''s Bar")
+        self.assertEqual(html(x=b"Moe's Bar"), u"Moe''s Bar")
+
+        if six.PY3:
+            self.assertEqual(html(x=u"Moe's B%sr" % special),
+                             u"Moe''s B%sr" % special)
+            self.assertEqual(html(x=b"Moe's B%sr" % special.encode('UTF-8')),
+                             u"Moe''s B%sr" % special)
+        else:
+            self.assertEqual(html(x=u"Moe's B%sr" % special),
+                             "Moe''s B%sr" % special.encode('UTF-8'))
+            self.assertEqual(html(x=b"Moe's B%sr" % special.encode('UTF-8')),
+                             b"Moe''s B%sr" % special.encode('UTF-8'))
 
     def test_fmt(self):
         html = self.doc_class(

--- a/src/DocumentTemplate/tests/test_DT_Var.py
+++ b/src/DocumentTemplate/tests/test_DT_Var.py
@@ -15,6 +15,8 @@
 
 import unittest
 
+import six
+
 
 class TestNewlineToBr(unittest.TestCase):
 
@@ -95,63 +97,11 @@ class TestUrlQuoting(unittest.TestCase):
         self.assertEqual(
             url_unquote_plus(quoted_utf8_value), utf8_value)
 
-    def test_bytes_sql_quote(self):
-        from DocumentTemplate.DT_Var import bytes_sql_quote
-        self.assertEqual(bytes_sql_quote(b""), b"")
-        self.assertEqual(bytes_sql_quote(b"a"), b"a")
-
-        self.assertEqual(bytes_sql_quote(b"Can't"), b"Can''t")
-        self.assertEqual(bytes_sql_quote(b"Can\'t"), b"Can''t")
-        self.assertEqual(bytes_sql_quote(br"Can\'t"), b"Can\\''t")
-
-        self.assertEqual(bytes_sql_quote(b"Can\\ I?"), b"Can\\ I?")
-        self.assertEqual(bytes_sql_quote(br"Can\ I?"), b"Can\\ I?")
-
-        self.assertEqual(
-            bytes_sql_quote(b'Just say "Hello"'), b'Just say "Hello"')
-
-        self.assertEqual(
-            bytes_sql_quote(b'Hello\x00World'), b'HelloWorld')
-        self.assertEqual(
-            bytes_sql_quote(b'\x00Hello\x00\x00World\x00'), b'HelloWorld')
-
-        self.assertEqual(
-            bytes_sql_quote(b"carriage\rreturn"), b"carriagereturn")
-        self.assertEqual(bytes_sql_quote(b"line\nbreak"), b"line\nbreak")
-        self.assertEqual(bytes_sql_quote(b"tab\t"), b"tab\t")
-
-    def test_text_sql_quote(self):
-        from DocumentTemplate.DT_Var import text_sql_quote
-        self.assertEqual(text_sql_quote(u""), u"")
-        self.assertEqual(text_sql_quote(u"a"), u"a")
-
-        self.assertEqual(text_sql_quote(u"Can't"), u"Can''t")
-        self.assertEqual(text_sql_quote(u"Can\'t"), u"Can''t")
-        # SyntaxError on Python 3.
-        # self.assertEqual(text_sql_quote(ur"Can\'t"), u"Can\\\\''t")
-
-        self.assertEqual(text_sql_quote(u"Can\\ I?"), u"Can\\ I?")
-        # SyntaxError on Python 3.
-        # self.assertEqual(text_sql_quote(ur"Can\ I?"), u"Can\\\\ I?")
-
-        self.assertEqual(
-            text_sql_quote(u'Just say "Hello"'), u'Just say "Hello"')
-
-        self.assertEqual(
-            text_sql_quote(u'Hello\x00World'), u'HelloWorld')
-        self.assertEqual(
-            text_sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
-
-        self.assertEqual(
-            text_sql_quote(u"carriage\rreturn"), u"carriagereturn")
-        self.assertEqual(text_sql_quote(u"line\nbreak"), u"line\nbreak")
-        self.assertEqual(text_sql_quote(u"tab\t"), u"tab\t")
-
     def test_sql_quote(self):
         from DocumentTemplate.DT_Var import sql_quote
         self.assertEqual(sql_quote(u""), u"")
         self.assertEqual(sql_quote(u"a"), u"a")
-        self.assertEqual(sql_quote(b"a"), b"a")
+        self.assertEqual(sql_quote(b"a"), u"a")
 
         self.assertEqual(sql_quote(u"Can't"), u"Can''t")
         self.assertEqual(sql_quote(u"Can\'t"), u"Can''t")
@@ -174,11 +124,15 @@ class TestUrlQuoting(unittest.TestCase):
             sql_quote(u'\x00Hello\x00\x00World\x00'), u'HelloWorld')
 
         self.assertEqual(u"\xea".encode("utf-8"), b"\xc3\xaa")
-        self.assertEqual(sql_quote(u"\xea'"), u"\xea''")
-        self.assertEqual(sql_quote(b"\xc3\xaa'"), b"\xc3\xaa''")
+        if six.PY3:
+            self.assertEqual(sql_quote(b"\xc3\xaa'"), u"\xea''")
+            self.assertEqual(sql_quote(u"\xea'"), u"\xea''")
+        else:
+            self.assertEqual(sql_quote(b"\xc3\xaa'"), b"\xc3\xaa''")
+            self.assertEqual(sql_quote(u"\xea'"), b"\xc3\xaa''")
 
         self.assertEqual(
-            sql_quote(b"carriage\rreturn"), b"carriagereturn")
+            sql_quote(b"carriage\rreturn"), u"carriagereturn")
         self.assertEqual(
             sql_quote(u"carriage\rreturn"), u"carriagereturn")
         self.assertEqual(sql_quote(u"line\nbreak"), u"line\nbreak")


### PR DESCRIPTION
Fixes #54 

This PR simplifies `sql_quote` and makes sure it returns native strings, like all other formatting functions used in `dtml-var`.
