### PR TITLE
Set `tree-s` cookie for `dtml-tree` with `SameSite=Lax`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2
@@ -53,7 +54,7 @@ jobs:
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls coverage-python-version
+        pip install coveralls
         coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "3a251aab94eff9cf2aa2fd87d7266593251e4b76"
+commit-id = "b5df3766ff8923477f3d24729b19504f0c401a2e"
 
 [python]
 with-pypy = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Set the ``tree-s`` cookie for ``dtml-tree`` tags with ``SameSite=Lax``.
+  The tree tag never set this attribute. That causes modern browsers to show
+  warnings in the browser console and break tree displays in the future.
+  See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/
+  for information about the ``SameSite`` cookie attribute and why its handling
+  in browsers is changing. 
+
 - Add support for Python 3.10.
 
 - Drop support for Python 3.5.

--- a/src/TreeDisplay/TreeTag.py
+++ b/src/TreeDisplay/TreeTag.py
@@ -241,7 +241,7 @@ def tpRender(self, md, section, args,
     if state is substate and not ('single' in args and args['single']):
         state = state or ([id],)
         state = encode_seq(state)
-        md['RESPONSE'].setCookie('tree-s', state)
+        md['RESPONSE'].setCookie('tree-s', state, same_site='Lax')
 
     return ''.join(data)
 

--- a/src/TreeDisplay/tests.py
+++ b/src/TreeDisplay/tests.py
@@ -18,8 +18,10 @@ from TreeDisplay import TreeTag
 
 class FakeResponse:
 
-    def setCookie(self, name, value):
+    def setCookie(self, name, value, **kw):
         setattr(self, name, value)
+        for key, value in kw.items():
+            setattr(self, key, value)
 
 
 class DummyContent:
@@ -40,6 +42,9 @@ class DummyFolder:
 
 class TestTreeTag(unittest.TestCase):
 
+    def setUp(self):
+        self.response = FakeResponse()
+
     @property
     def doc_class(self):
         from DocumentTemplate.DT_HTML import HTML
@@ -47,15 +52,17 @@ class TestTreeTag(unittest.TestCase):
 
     def _render(self, text, **kw):
         html = self.doc_class(text)
-        return html(URL='/', RESPONSE=FakeResponse(), **kw)
+        return html(URL='/', RESPONSE=self.response, **kw)
 
     def test_instantiation_empty(self):
         res = self._render('<dtml-tree fldr></dtml-tree>', fldr=1)
         self.assertEqual(res, '<table cellspacing="0">\n</table>\n')
+        self.assertEqual(self.response.same_site, 'Lax')
 
     def test_instantiation(self):
         res = self._render('<dtml-tree fldr></dtml-tree>', fldr=DummyFolder())
         self.assertEqual(res, EMPTY_TREE)
+        self.assertEqual(self.response.same_site, 'Lax')
 
     def test_encode_decode_seq(self):
         state = [['AAAAAAAAAAE=', [['AAAAAAAAAAY=']]]]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands_pre =
     py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
-    {envbindir}/test {posargs:-cv}
+    {envdir}/bin/test {posargs:-cv}
 
 [testenv:lint]
 basepython = python3
@@ -60,16 +60,14 @@ allowlist_externals =
 deps =
     {[testenv]deps}
     coverage
-    coverage-python-version
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run {envbindir}/test {posargs:-cv}
+    coverage run {envdir}/bin/test {posargs:-cv}
     coverage html
     coverage report -m --fail-under=74
 
 [coverage:run]
 branch = True
-plugins = coverage_python_version
 source = DocumentTemplate
 
 [coverage:report]


### PR DESCRIPTION
The tree tag never set the `SameSite` attribute. That causes modern browsers to show warnings in the browser console and break tree displays in the future. Example: https://community.plone.org/t/same-site-cookie/12680

See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/ for information about the ``SameSite`` cookie attribute and why its handling in browsers is changing. 

I also updated the package configuration.