### PR TITLE
Be more resilient on sorting if the getter returns `None`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Add preliminary support for Python 3.12rc1
 
+- Be more resilient on sorting if the getter returns ``None``.
+
+
 4.4 (2022-01-12)
 ----------------
 

--- a/src/DocumentTemplate/DT_In.py
+++ b/src/DocumentTemplate/DT_In.py
@@ -829,6 +829,8 @@ class InClass:
                                 akey = akey()
                             except Exception:
                                 pass
+                        if akey is None:
+                            akey = _Smallest
                         k.append(akey)
                 else:  # One sort key.
                     if mapping:
@@ -840,6 +842,8 @@ class InClass:
                             k = k()
                         except Exception:
                             k = _Smallest
+                    if k is None:
+                        k = _Smallest
 
             s.append((k, client))
 

--- a/src/DocumentTemplate/tests/test_DT_In.py
+++ b/src/DocumentTemplate/tests/test_DT_In.py
@@ -48,6 +48,42 @@ class TestIn(unittest.TestCase):
             {'key': 'c', 'data': '3'},
         ], result)
 
+    def test_sort_sequence__02(self):
+        """It does not break on sort value `None`, sorts smallest."""
+        stmt = self._makeOne('seq', 'mapping', 'sort=data')
+        seq = [
+            {'key': 'c', 'data': '3'},
+            {'key': 'a', 'data': '1'},
+            {'key': 'b', 'data': '2'},
+            {'key': 'a', 'data': None},
+        ]
+        result = stmt.sort_sequence(seq, 'key')
+        breakpoint()
+        self.assertEqual([
+            {'key': 'a', 'data': None},
+            {'key': 'a', 'data': '1'},
+            {'key': 'b', 'data': '2'},
+            {'key': 'c', 'data': '3'},
+        ], result)
+
+    def test_sort_sequence__03(self):
+        """It does not break on sort value `None`, multisorts smallest."""
+        stmt = self._makeOne('seq', 'mapping', 'sort=key,data')
+        seq = [
+            {'key': 'c', 'data': '3'},
+            {'key': 'a', 'data': '1'},
+            {'key': 'b', 'data': '2'},
+            {'key': 'a', 'data': None},
+        ]
+        result = stmt.sort_sequence(seq, 'key')
+        breakpoint()
+        self.assertEqual([
+            {'key': 'a', 'data': None},
+            {'key': 'a', 'data': '1'},
+            {'key': 'b', 'data': '2'},
+            {'key': 'c', 'data': '3'},
+        ], result)
+
 
 class DT_In_Tests(unittest.TestCase):
     """Functional testing ..DT_In.InClass."""


### PR DESCRIPTION
This issue occurred during a migration from Python 2 to Python 3, where those lines https://github.com/zopefoundation/DocumentTemplate/blob/59d5b230c08536d5d049faf9ca82ae671c3035ae/src/DocumentTemplate/DT_In.py#L851-L855 were newly executed. Casting the `None` to `_Smallest` at least keeps the sorting reasonable. 

The error prevented is e.g.
```
  File ".../DocumentTemplate/src/DocumentTemplate/DT_In.py", line 857, in sort_sequence
    s.sort(key=itemgetter(0))
TypeError: '<' not supported between instances of 'NoneType' and 'int'
``` 