### PR TITLE
prevent builtin shadowing in DTML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ----------------
 
 - Prevent builtins shadowing in DTML Var.
+  (`Zope#1285 <https://github.com/zopefoundation/Zope/issues/1285>`_)
 
 
 5.1 (2026-01-19)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 5.2 (unreleased)
 ----------------
 
+- Prevent builtins shadowing in DTML Var.
+
 
 5.1 (2026-01-19)
 ----------------

--- a/src/DocumentTemplate/DT_Util.py
+++ b/src/DocumentTemplate/DT_Util.py
@@ -204,6 +204,9 @@ class Eval(RestrictionCapableEval):
         d.update(self.globals)
         for name in self.used:
             __traceback_info__ = name
+            # Don't try to override builtins, since they need to be protected
+            if d["__builtins__"] and name in d["__builtins__"]:
+                continue
             try:
                 if name not in d:
                     d[name] = md.getitem(name, 0)

--- a/src/DocumentTemplate/DT_Util.py
+++ b/src/DocumentTemplate/DT_Util.py
@@ -205,7 +205,7 @@ class Eval(RestrictionCapableEval):
         for name in self.used:
             __traceback_info__ = name
             # Don't try to override builtins, since they need to be protected
-            if d["__builtins__"] and name in d["__builtins__"]:
+            if d.get("__builtins__") and name in d["__builtins__"]:
                 continue
             try:
                 if name not in d:

--- a/src/DocumentTemplate/tests/testDTML.py
+++ b/src/DocumentTemplate/tests/testDTML.py
@@ -422,22 +422,30 @@ foo bar
             def __call__(self, *args, **kwargs):
                 return f"rendering: {self.x}"
 
+            def __len__(self):
+                return len(self.x)
+
         foo = C("foo")
         foo.str = bar = C("bar")
+        foo.len = baz = C("baz")
         expected = (
             '''
             foo,
             foo,
             bar,
             rendering: foo,
-            rendering: bar''')
+            rendering: bar,
+            3,
+            rendering: baz''')
         res = self.doc_class(
             '''
             <dtml-var "foo.x">,
             <dtml-var "str(foo.x)">,
             <dtml-var "foo.str.x">,
             <dtml-var "foo()">,
-            <dtml-var "foo.str()">''')(**{"foo": foo, "str": bar})
+            <dtml-var "foo.str()">,
+            <dtml-var "len(foo)">,
+            <dtml-var "foo.len()">''')(**{"foo": foo, "str": bar, "len": baz})
         self.assertEqual(res, expected)
 
     def testWith(self):

--- a/src/DocumentTemplate/tests/testDTML.py
+++ b/src/DocumentTemplate/tests/testDTML.py
@@ -408,6 +408,38 @@ foo bar
             <dtml-var expr="_.render(i.h2)">''')(i=C())
         self.assertEqual(res, expected)
 
+    def test_subitem_with_builtins_names(self):
+        # Test builtins names shadowing
+        import Acquisition
+        from ExtensionClass import Base
+
+        class C(Base, Acquisition.Implicit):
+            __allow_access_to_unprotected_subobjects__ = 1
+
+            def __init__(self, x):
+                self.x = x
+
+            def __call__(self, *args, **kwargs):
+                return f"rendering: {self.x}"
+
+        foo = C("foo")
+        foo.str = bar = C("bar")
+        expected = (
+            '''
+            foo,
+            foo,
+            bar,
+            rendering: foo,
+            rendering: bar''')
+        res = self.doc_class(
+            '''
+            <dtml-var "foo.x">,
+            <dtml-var "str(foo.x)">,
+            <dtml-var "foo.str.x">,
+            <dtml-var "foo()">,
+            <dtml-var "foo.str()">''')(**{"foo": foo, "str": bar})
+        self.assertEqual(res, expected)
+
     def testWith(self):
         class person:
             __allow_access_to_unprotected_subobjects__ = 1


### PR DESCRIPTION
- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.

-----
This PR prevents expression evaluation in DocumentTemplate from overriding or shadowing builtins (eg. str, len, ...).